### PR TITLE
#Ft GenServer - implement KV.Registry to manage buckets

### DIFF
--- a/lib/kv/registry.ex
+++ b/lib/kv/registry.ex
@@ -34,7 +34,7 @@ defmodule KV.Registry do
   def init(:ok) do
     names = %{}
     refs = %{}
-    {:ok, %{names, refs}}
+    {:ok, {names, refs}}
   end
 
   @impl true
@@ -55,6 +55,13 @@ defmodule KV.Registry do
       {:noreply, {names, refs}}
       # {:noreply, Map.put(names, name, bucket)}
     end
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, {names, refs}) do
+    {name, refs} = Map.pop(refs, ref)
+    names = Map.delete(names, name)
+    {:noreply, {names, refs}}
   end
 
   @impl true

--- a/lib/kv/registry.ex
+++ b/lib/kv/registry.ex
@@ -32,21 +32,35 @@ defmodule KV.Registry do
   # The only required callback is `init/1`.
   @impl true
   def init(:ok) do
-    {:ok, %{}}
+    names = %{}
+    refs = %{}
+    {:ok, %{names, refs}}
   end
 
   @impl true
-  def handle_call({:lookup, name}, _from, names) do
-    {:reply, Map.fetch(names, name), names}
+  def handle_call({:lookup, name}, _from, state) do
+    {names, _} = state
+    {:reply, Map.fetch(names, name), state}
   end
 
   @impl true
-  def handle_cast({:create, name}, names) do
+  def handle_cast({:create, name}, {names, refs}) do
     if Map.has_key?(names, name) do
-      {:noreply, names}
+      {:noreply, {names, refs}}
     else
       {:ok, bucket} = KV.Bucket.start_link([])
-      {:noreply, Map.put(names, name, bucket)}
+      ref = Process.monitor(bucket)
+      refs = Map.put(refs, ref, name)
+      names = Map.put(names, name, bucket)
+      {:noreply, {names, refs}}
+      # {:noreply, Map.put(names, name, bucket)}
     end
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    require Logger
+    Logger.debug("Unexpected message in KV.Registry: #{inspect(msg)}")
+    {:noreply, state}
   end
 end

--- a/test/kv/bucket_test.exs
+++ b/test/kv/bucket_test.exs
@@ -2,10 +2,12 @@ defmodule KV.BucketTest do
   use ExUnit.Case, async: true
 
   @doc """
-  setup macro defines a callback that runs before every test, in the sae process as the test itself.
+  setup macro defines a callback that runs before every test, 
+  in the same process as the test itself.
   """
   setup do
-    {:ok, bucket} = KV.Bucket.start_link([])
+    # {:ok, bucket} = KV.Bucket.start_link([])
+    bucket = start_supervised!(KV.Bucket)
     %{bucket: bucket}
   end
 

--- a/test/kv/registry_test.exs
+++ b/test/kv/registry_test.exs
@@ -1,0 +1,32 @@
+defmodule KV.RegistryTest do
+  use ExUnit.Case, async: true
+
+  @doc """
+  setup macro defines a callback that runs before every test, 
+  in the same process as the test itself.
+
+  We will spawn the server on a setup callback and use it throughout our tests. 
+  """
+  setup do
+    registry = start_supervised!(KV.Registry)
+    %{registry: registry}
+  end
+
+  test "spawn buckets", %{registry: registry} do
+    assert KV.Registry.lookup(registry, "shopping") == :error
+
+    KV.Registry.create(registry, "shopping")
+    assert {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
+
+    KV.Bucket.put(bucket, "milk", 1)
+    assert KV.Bucket.get(bucket, "milk") == 1
+  end
+
+  test "removes buckets on exit", %{registry: registry} do
+    KV.Registry.create(registry, "shopping")
+    {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
+    Agent.stop(bucket)
+    assert KV.Registry.lookup(registry, "shopping") == :error
+  end
+
+end


### PR DESCRIPTION
#### What does this PR do?
It uses GenServer to create a registry to manage buckets

#### Description of task to be completed?
- modify handle_call and handle_cast
- implement handle_info callback
- write test for removing buckets on exit
- implement handle_info callback to handle monitoring messages
- implement a catch-all clause for handle_info that discard and logs any unknown message

#### How should this be manually tested?
- Follow the steps below:
  - Run the following commands in your terminal
`git clone https://github.com/Andhrah/key-value-store.git`
- Open the project folder `cd key-value-store` in your terminal
- Open the project folder in your `text editor` of choice.
- Run `mix compile` to compile the app.
- Once the project/app is compiled, you can start an iex session by running: `iex -S mix`
- then test this feature by running `{:ok, registry} = KV.Registry.start_link([])` 
- Login to the app.
#### What are the relevant stories id?
N/A
#### Screenshots (if appropriate)
N/A